### PR TITLE
Fix Fuse

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,10 @@ let package = Package(
 if Context.environment["SKIP_BRIDGE"] ?? "0" != "0" {
     package.dependencies += [.package(url: "https://source.skip.tools/skip-fuse-ui.git", from: "1.0.0")]
     package.targets.forEach({ target in
-        target.dependencies += [.product(name: "SkipFuseUI", package: "skip-fuse-ui")]
+        target.dependencies += [
+            .product(name: "SkipFuseUI", package: "skip-fuse-ui"),
+            .product(name: "SkipSwiftUI", package: "skip-fuse-ui"),
+        ]
     })
     // all library types must be dynamic to support bridging
     package.products = package.products.map({ product in

--- a/Sources/SkipAuthenticationServices/SkipAuthenticationServices.swift
+++ b/Sources/SkipAuthenticationServices/SkipAuthenticationServices.swift
@@ -222,4 +222,13 @@ struct CustomTabsIntentListener : Consumer<Intent> {
     }
 }
 #endif
+#else
+import SkipSwiftUI
+
+extension EnvironmentValues {
+    public var webAuthenticationSession: WebAuthenticationSession {
+        get { fatalError() }
+        set { fatalError() }
+    }
+}
 #endif

--- a/Sources/SkipAuthenticationServices/SkipAuthenticationServices.swift
+++ b/Sources/SkipAuthenticationServices/SkipAuthenticationServices.swift
@@ -231,4 +231,7 @@ extension EnvironmentValues {
         set { fatalError() }
     }
 }
+
+extension WebAuthenticationSession: @unchecked Sendable {}
+
 #endif


### PR DESCRIPTION
* Fixes #1

There are two commits here, and I don't really like either one of them.

The first commit adds an `#else` block to the `#if !SKIP_BRIDGE` wrapping the file. We need this because `skip-fuse-ui`'s `SkipSwiftUI` `EnvironmentValues` isn't the same object as `skip-ui`'s `EnvironmentValues`; this is the reason why #1 happens.

Unfortunately, that also adds a warning to the build, "warning: When bridging API from a transpiled module, place all code within a `#if !SKIP_BRIDGE` condition"

(Is there a better way to implement this that won't trigger the warning??)

The second commit makes the `WebAuthenticationSession` bridge `Sendable`, but only in Skip Fuse. I don't understand why this is necessary, but when I try to build `skipapp-showcase-fuse` with just the first commit, it fails with `#SendingRisksDataRace` errors.

<details><summary>`#SendingRisksDataRace` errors</summary>
<p>

```
/Users/dfabulich/git/skiphack/skipapp-showcase-fuse/Sources/ShowcaseFuse/WebAuthenticationSessionPlayground.swift:89:71: error: sending 'self.webAuthenticationSession' risks causing data races [#SendingRisksDataRace]
 87 |                 let urlWithToken: URL
 88 |                 if #available(iOS 17.4, *) {
 89 |                     urlWithToken = try await webAuthenticationSession.authenticate(
    |                                                                       |- error: sending 'self.webAuthenticationSession' risks causing data races [#SendingRisksDataRace]
    |                                                                       `- note: sending main actor-isolated 'self.webAuthenticationSession' to nonisolated instance method 'authenticate(using:callback:preferredBrowserSession:additionalHeaderFields:)' risks causing data races between nonisolated and main actor-isolated uses
 90 |                         using: URL(string: "https://push.skip.tools/webauth-demo/?scheme=org.appfair.app.showcase")!,
 91 |                         callback: .customScheme("org.appfair.app.showcase"),

/Users/dfabulich/git/skiphack/skipapp-showcase-fuse/Sources/ShowcaseFuse/WebAuthenticationSessionPlayground.swift:96:71: error: sending 'self.webAuthenticationSession' risks causing data races [#SendingRisksDataRace]
 94 |                     )
 95 |                 } else {
 96 |                     urlWithToken = try await webAuthenticationSession.authenticate(
    |                                                                       |- error: sending 'self.webAuthenticationSession' risks causing data races [#SendingRisksDataRace]
    |                                                                       `- note: sending main actor-isolated 'self.webAuthenticationSession' to nonisolated instance method 'authenticate(using:callbackURLScheme:preferredBrowserSession:)' risks causing data races between nonisolated and main actor-isolated uses
 97 |                         using: URL(string: "https://push.skip.tools/webauth-demo/?scheme=org.appfair.app.showcase")!,
 98 |                         callbackURLScheme: "org.appfair.app.showcase",

[#SendingRisksDataRace]: <https://docs.swift.org/compiler/documentation/diagnostics/sending-risks-data-race>
```

</p>
</details> 

I don't understand why this is happening. `skipapp-showcase` compiles just fine. SwiftUI's [`WebAuthenticationSession`](https://developer.apple.com/documentation/authenticationservices/webauthenticationsession) is `@MainActor`, but not `Sendable`. What I do know is that even if I add `@MainActor` to `WebAuthenticationSession` in `SkipAuthenticationServices.swift`, the generated bridge does _not_ have `@MainActor`.

It appears to be a pattern to add these bogus(?) `@unchecked Sendable` extensions in `skip-fuse-ui`, so I did that, too.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor generated the first draft of this PR. It tried a million things, and eventually found this. I manually tested it in the Lite and Fuse Showcase apps.

* https://github.com/skiptools/skipapp-showcase-fuse/pull/58